### PR TITLE
[✨Feature] TTSで生成するときに設定できる項目を増やす

### DIFF
--- a/src/ITalkToSpeech.cs
+++ b/src/ITalkToSpeech.cs
@@ -10,18 +10,18 @@ public interface ITalkToSpeech
     /// </summary>
     /// <param name="modelUuid">モデルのUUID</param>
     /// <param name="text">合成するテキスト</param>
-    /// <param name="format">出力フォーマット（デフォルトは "mp3"）</param>
+    /// <param name="options">音声合成のオプション</param>
     /// <returns>音声データのバイト配列</returns>
-    Task<byte[]> SynthesizeAsync(string modelUuid, string text, string format = "mp3");
+    Task<byte[]> SynthesizeAsync(string modelUuid, string text, TalkToSpeechOptions? options = null);
 
     /// <summary>
     /// 音声合成を行いストリーミングします。
     /// </summary>
     /// <param name="modelUuid">モデルのUUID</param>
     /// <param name="text">合成するテキスト</param>
-    /// <param name="format">出力フォーマット（デフォルトは "mp3"）</param>
+    /// <param name="options">音声合成のオプション</param>
     /// <returns>音声データのストリーム</returns>
-    Task<Stream> SynthesizeStreamAsync(string modelUuid, string text, string format = "mp3");
+    Task<Stream> SynthesizeStreamAsync(string modelUuid, string text, TalkToSpeechOptions? options = null);
 
     /// <summary>
     /// 音声合成を行います。
@@ -29,7 +29,7 @@ public interface ITalkToSpeech
     /// </summary>
     /// <param name="modelUuid">モデルのUUID</param>
     /// <param name="text">合成するテキスト</param>
-    /// <param name="format">出力フォーマット（デフォルトは "mp3"）</param>
+    /// <param name="options">音声合成のオプション</param>
     /// <returns>音声データとヘッダコンテンツを含むTTSコンテンツ</returns>
-    Task<TTSContents> SynthesizeWithContentsAsync(string modelUuid, string text, string format = "mp3");
+    Task<TTSContents> SynthesizeWithContentsAsync(string modelUuid, string text, TalkToSpeechOptions? options = null);
 }

--- a/src/MediaType.cs
+++ b/src/MediaType.cs
@@ -8,3 +8,19 @@ public enum MediaType
     AAC,
     OPUS,
 }
+
+public static class MediaTypeExtensions
+{
+    public static string ToFormatString(this MediaType mediaType)
+    {
+        return mediaType switch
+        {
+            MediaType.WAV => "wav",
+            MediaType.FLAC => "flac",
+            MediaType.MP3 => "mp3",
+            MediaType.AAC => "aac",
+            MediaType.OPUS => "opus",
+            _ => throw new ArgumentOutOfRangeException(nameof(mediaType), mediaType, null)
+        };
+    }
+}

--- a/src/TalkToSpeechOptions.cs
+++ b/src/TalkToSpeechOptions.cs
@@ -1,0 +1,173 @@
+namespace Aivis;
+
+/// <summary>
+/// Talk to Speech (TTS) APIのオプションを定義するクラスです。
+/// </summary>
+public class TalkToSpeechOptions
+{
+    /// <summary>
+    /// 音声合成モデルの「話者 UUID」を指定します。ここで指定された話者を音声合成に利用します。
+    /// 話者 UUID は、AivmManifest.speakers[].uuid の値を指定します。
+    ///
+    /// 単一話者モデルでは指定の必要はありません。 当該モデルに存在しない話者の UUID を指定すると 422 エラーが発生します。
+    /// 複数話者モデルでこの値が省略された場合は、当該モデルのデフォルト話者を音声合成に利用します。
+    /// </summary>
+    public Guid? SpeakerUuid { get; set; }
+
+    private int styleId = 0;
+    /// <summary>
+    /// 音声合成モデルの話者のスタイル ID を 0 ~ 31 の範囲で指定します。通常、ノーマルスタイルの ID は 0 です。
+    /// スタイル ID には、AivmManifest.speakers[].styles[].local_id の値を指定します。 style_name とは併用できません。
+    /// 
+    /// 当該モデル → 話者 → スタイルに存在しないスタイル ID を指定すると 422 エラーが発生します。
+    /// 未指定時は、当該話者のノーマルスタイルを音声合成に利用します。
+    /// </summary>
+    public int StyleId
+    {
+        get => styleId;
+        set
+        {
+            if (0 <= value && value <= 31)
+            {
+                styleId = value;
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "StyleId must be between 0 and 31.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// 指定されたユーザー辞書 UUID に対応するユーザー辞書を、音声合成時に適用します。
+    /// 
+    /// ユーザー辞書を利用するには、事前にユーザー辞書 API を通してユーザー辞書を作成しておく必要があります。
+    /// 未指定時は、デフォルト辞書のみを適用した状態で音声合成を行います。
+    /// </summary>
+    public Guid? UserDictionaryUuid { get; set; }
+
+    /// <summary>
+    /// text に記述された SSML タグのサブセットの解釈を有効にするかを指定します。デフォルトで有効です。
+    /// 現在、SSML のサブセット (&lt;break time/strength=&quot;...&quot;&gt;, &lt;prosody rate/pitch/volume=&quot;...&quot;&gt;, &lt;sub alias=&quot;...&quot;&gt;, &lt;p&gt;, &lt;s&gt;) にのみ対応しています。
+    /// 
+    /// true の場合、text の内容を SSML (XML) として解釈します。タグとして解釈されうる制御文字はエスケープが必要です。
+    /// false の場合、text の内容はすべてプレーンテキストとして扱われ、SSML タグは解釈しません。
+    /// </summary>
+    public bool UseSsml { get; set; } = true;
+
+
+    /// <summary>
+    /// 音声データの出力形式を指定します。用途に応じて最適な形式を選択してください。
+    /// wav, flac, mp3, aac, opus
+    /// </summary>
+    public MediaType OutputFormat { get; set; } = MediaType.MP3;
+
+    /// <summary>
+    /// TalkToSpeechOptions のデフォルトコンストラクタです。
+    /// </summary>
+    public TalkToSpeechOptions()
+    {
+        // デフォルトコンストラクタ
+    }
+
+    /// <summary>
+    /// スピーカーのUUIDを設定します。
+    /// 単一話者の場合設定は不要です。
+    /// </summary>
+    /// <param name="speakerUuid">スピーカーのUUID</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetSpeakerUuid(string? speakerUuid)
+    {
+        if (speakerUuid is null)
+        {
+            return SetSpeakerUuid((Guid?)null);
+        }
+
+        if (Guid.TryParse(speakerUuid, out var uuid))
+        {
+            return SetSpeakerUuid(uuid);
+        }
+        else
+        {
+            throw new ArgumentException("Invalid UUID format", nameof(speakerUuid));
+        }
+    }
+
+    /// <summary>
+    /// スピーカーのUUIDを設定します。
+    /// 単一話者の場合設定は不要です。
+    /// </summary>
+    /// <param name="speakerUuid">スピーカーのUUID</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetSpeakerUuid(Guid? speakerUuid)
+    {
+        SpeakerUuid = speakerUuid;
+        return this;
+    }
+
+    /// <summary>
+    /// 話者スタイルを設定します。
+    /// </summary>
+    /// <param name="styleId">話者スタイル</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetStyle(int styleId)
+    {
+        StyleId = styleId;
+        return this;
+    }
+
+    /// <summary>
+    /// ユーザー辞書UUIDを設定します。
+    /// </summary>
+    /// <param name="userDictionaryUuid">ユーザー辞書のUUID</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetUserDictionary(string? userDictionaryUuid)
+    {
+        if (userDictionaryUuid is null)
+        {
+            return SetUserDictionary((Guid?)null);
+        }
+
+        if (Guid.TryParse(userDictionaryUuid, out var uuid))
+        {
+            return SetUserDictionary(uuid);
+        }
+        else
+        {
+            throw new ArgumentException("Invalid UUID format", nameof(userDictionaryUuid));
+        }
+    }
+
+    /// <summary>
+    /// ユーザー辞書UUIDを設定します。
+    /// </summary>
+    /// <param name="userDictionaryUuid">ユーザー辞書のUUID</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetUserDictionary(Guid? userDictionaryUuid)
+    {
+        UserDictionaryUuid = userDictionaryUuid;
+        return this;
+    }
+
+    /// <summary>
+    /// Ssmlの使用を設定します。
+    /// </summary>
+    /// <param name="useSsml">Ssmlを使用する場合はtrue</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetUseSsml(bool useSsml = true)
+    {
+        UseSsml = useSsml;
+        return this;
+    }
+
+    /// <summary>
+    /// 出力するファイルフォーマットを設定します。
+    /// </summary>
+    /// <param name="format">出力フォーマット</param>
+    /// <returns>TalkToSpeechOptionsのインスタンス</returns>
+    public TalkToSpeechOptions SetOutputFormat(MediaType format)
+    {
+        OutputFormat = format;
+        return this;
+    }
+}

--- a/tests/AivisTTSClientTests.cs
+++ b/tests/AivisTTSClientTests.cs
@@ -83,7 +83,8 @@ public class AivisTTSClientTests
         SetupHttpResponse(responseMessage);
 
         var client = new AivisTTSClient(_options);
-        await client.SynthesizeAsync("550e8400-e29b-41d4-a716-446655440000", "テストテキスト", "wav");
+        var options = new TalkToSpeechOptions().SetOutputFormat(MediaType.WAV);
+        await client.SynthesizeAsync("550e8400-e29b-41d4-a716-446655440000", "テストテキスト", options);
 
         VerifyHttpRequest("/v1/tts/synthesize", requestBody =>
         {
@@ -187,7 +188,8 @@ public class AivisTTSClientTests
         SetupHttpResponse(responseMessage);
 
         var client = new AivisTTSClient(_options);
-        await client.SynthesizeAsync("550e8400-e29b-41d4-a716-446655440000", "テストテキスト", "wav");
+        var options = new TalkToSpeechOptions().SetOutputFormat(MediaType.WAV);
+        await client.SynthesizeAsync("550e8400-e29b-41d4-a716-446655440000", "テストテキスト", options);
 
         VerifyHttpRequest("/v1/tts/synthesize", requestBody =>
         {

--- a/tests/TalkToSpeechOptionsTests.cs
+++ b/tests/TalkToSpeechOptionsTests.cs
@@ -1,0 +1,317 @@
+namespace Aivis.Tests;
+
+public class TalkToSpeechOptionsTests
+{
+    [Fact]
+    public void Constructor_DefaultValues_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+
+        Assert.Null(options.SpeakerUuid);
+        Assert.Equal(0, options.StyleId);
+        Assert.Null(options.UserDictionaryUuid);
+        Assert.True(options.UseSsml);
+        Assert.Equal(MediaType.MP3, options.OutputFormat);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(15)]
+    [InlineData(31)]
+    public void StyleId_ValidRange_SetsCorrectly(int styleId)
+    {
+        var options = new TalkToSpeechOptions();
+
+        options.StyleId = styleId;
+
+        Assert.Equal(styleId, options.StyleId);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(32)]
+    [InlineData(100)]
+    public void StyleId_InvalidRange_ThrowsArgumentOutOfRangeException(int styleId)
+    {
+        var options = new TalkToSpeechOptions();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.StyleId = styleId);
+    }
+
+    [Fact]
+    public void SpeakerUuid_ValidGuid_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+
+        options.SpeakerUuid = uuid;
+
+        Assert.Equal(uuid, options.SpeakerUuid);
+    }
+
+    [Fact]
+    public void SpeakerUuid_Null_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.SpeakerUuid = Guid.NewGuid();
+
+        options.SpeakerUuid = null;
+
+        Assert.Null(options.SpeakerUuid);
+    }
+
+    [Fact]
+    public void UserDictionaryUuid_ValidGuid_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+
+        options.UserDictionaryUuid = uuid;
+
+        Assert.Equal(uuid, options.UserDictionaryUuid);
+    }
+
+    [Fact]
+    public void UserDictionaryUuid_Null_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.UserDictionaryUuid = Guid.NewGuid();
+
+        options.UserDictionaryUuid = null;
+
+        Assert.Null(options.UserDictionaryUuid);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UseSsml_CanBeSet(bool useSsml)
+    {
+        var options = new TalkToSpeechOptions();
+
+        options.UseSsml = useSsml;
+
+        Assert.Equal(useSsml, options.UseSsml);
+    }
+
+    [Theory]
+    [InlineData(MediaType.WAV)]
+    [InlineData(MediaType.FLAC)]
+    [InlineData(MediaType.MP3)]
+    [InlineData(MediaType.AAC)]
+    [InlineData(MediaType.OPUS)]
+    public void OutputFormat_CanBeSet(MediaType format)
+    {
+        var options = new TalkToSpeechOptions();
+
+        options.OutputFormat = format;
+
+        Assert.Equal(format, options.OutputFormat);
+    }
+
+    [Fact]
+    public void SetSpeakerUuid_ValidGuidString_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+        var uuidString = uuid.ToString();
+
+        var result = options.SetSpeakerUuid(uuidString);
+
+        Assert.Equal(uuid, options.SpeakerUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetSpeakerUuid_ValidGuid_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+
+        var result = options.SetSpeakerUuid(uuid);
+
+        Assert.Equal(uuid, options.SpeakerUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetSpeakerUuid_NullString_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.SpeakerUuid = Guid.NewGuid();
+
+        var result = options.SetSpeakerUuid((string?)null);
+
+        Assert.Null(options.SpeakerUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetSpeakerUuid_NullGuid_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.SpeakerUuid = Guid.NewGuid();
+
+        var result = options.SetSpeakerUuid((Guid?)null);
+
+        Assert.Null(options.SpeakerUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetSpeakerUuid_InvalidGuidString_ThrowsArgumentException()
+    {
+        var options = new TalkToSpeechOptions();
+
+        var exception = Assert.Throws<ArgumentException>(() => options.SetSpeakerUuid("invalid-uuid"));
+        Assert.Equal("speakerUuid", exception.ParamName);
+        Assert.Contains("Invalid UUID format", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(15)]
+    [InlineData(31)]
+    public void SetStyle_ValidRange_SetsCorrectly(int styleId)
+    {
+        var options = new TalkToSpeechOptions();
+
+        var result = options.SetStyle(styleId);
+
+        Assert.Equal(styleId, options.StyleId);
+        Assert.Same(options, result);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(32)]
+    [InlineData(100)]
+    public void SetStyle_InvalidRange_ThrowsArgumentOutOfRangeException(int styleId)
+    {
+        var options = new TalkToSpeechOptions();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.SetStyle(styleId));
+    }
+
+    [Fact]
+    public void SetUserDictionary_ValidGuidString_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+        var uuidString = uuid.ToString();
+
+        var result = options.SetUserDictionary(uuidString);
+
+        Assert.Equal(uuid, options.UserDictionaryUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetUserDictionary_ValidGuid_SetsCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var uuid = Guid.NewGuid();
+
+        var result = options.SetUserDictionary(uuid);
+
+        Assert.Equal(uuid, options.UserDictionaryUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetUserDictionary_NullString_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.UserDictionaryUuid = Guid.NewGuid();
+
+        var result = options.SetUserDictionary((string?)null);
+
+        Assert.Null(options.UserDictionaryUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetUserDictionary_NullGuid_SetsToNull()
+    {
+        var options = new TalkToSpeechOptions();
+        options.UserDictionaryUuid = Guid.NewGuid();
+
+        var result = options.SetUserDictionary((Guid?)null);
+
+        Assert.Null(options.UserDictionaryUuid);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetUserDictionary_InvalidGuidString_ThrowsArgumentException()
+    {
+        var options = new TalkToSpeechOptions();
+
+        var exception = Assert.Throws<ArgumentException>(() => options.SetUserDictionary("invalid-uuid"));
+        Assert.Equal("userDictionaryUuid", exception.ParamName);
+        Assert.Contains("Invalid UUID format", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void SetUseSsml_CanBeSet(bool useSsml)
+    {
+        var options = new TalkToSpeechOptions();
+
+        var result = options.SetUseSsml(useSsml);
+
+        Assert.Equal(useSsml, options.UseSsml);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void SetUseSsml_DefaultParameter_SetsToTrue()
+    {
+        var options = new TalkToSpeechOptions();
+        options.UseSsml = false;
+
+        var result = options.SetUseSsml();
+
+        Assert.True(options.UseSsml);
+        Assert.Same(options, result);
+    }
+
+    [Theory]
+    [InlineData(MediaType.WAV)]
+    [InlineData(MediaType.FLAC)]
+    [InlineData(MediaType.MP3)]
+    [InlineData(MediaType.AAC)]
+    [InlineData(MediaType.OPUS)]
+    public void SetOutputFormat_CanBeSet(MediaType format)
+    {
+        var options = new TalkToSpeechOptions();
+
+        var result = options.SetOutputFormat(format);
+
+        Assert.Equal(format, options.OutputFormat);
+        Assert.Same(options, result);
+    }
+
+    [Fact]
+    public void FluentInterface_MethodChaining_WorksCorrectly()
+    {
+        var options = new TalkToSpeechOptions();
+        var speakerUuid = Guid.NewGuid();
+        var userDictionaryUuid = Guid.NewGuid();
+
+        var result = options
+            .SetSpeakerUuid(speakerUuid)
+            .SetStyle(10)
+            .SetUserDictionary(userDictionaryUuid)
+            .SetUseSsml(false)
+            .SetOutputFormat(MediaType.WAV);
+
+        Assert.Equal(speakerUuid, options.SpeakerUuid);
+        Assert.Equal(10, options.StyleId);
+        Assert.Equal(userDictionaryUuid, options.UserDictionaryUuid);
+        Assert.False(options.UseSsml);
+        Assert.Equal(MediaType.WAV, options.OutputFormat);
+        Assert.Same(options, result);
+    }
+}


### PR DESCRIPTION
## 📌 概要 / Summary

- TTS時のオプションを使えるようにする

## 🔧 変更内容 / Changes

- TTSのときにアウトプットフォーマットではなく、Optionsで渡すようにしました

## ✅ チェックリスト / Checklist

プルリクエストを提出する前に、以下のチェックを行ってください。

- [x] この変更は Issue / Discussion と関連しています（なければスキップ可）
- [x] ローカル環境でビルドとテストを実行しました（`dotnet build` / `dotnet test`）
- [x] 互換性や影響範囲について確認しました
- [x] 必要に応じてドキュメントを更新しました
- [x] ライセンスや著作権を侵害していないことを確認しました

## 🔍 関連する Issue / Related Issue

#50

## 📝 備考 / Notes

- `ITalkToSpeech`のメソッドに破壊的変更がはっています
  - オプション値のため、影響はない認識


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added TalkToSpeechOptions to configure speaker, style, user dictionary, SSML, and output format across synthesis methods.
  - Synthesis-with-contents now returns audio plus filename and related metadata.
- Refactor
  - Updated public synthesis methods to accept an optional options object instead of a format string.
- Tests
  - Added comprehensive tests for TalkToSpeechOptions and updated client tests to cover the new API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->